### PR TITLE
utils(params): support optional parameters and limit usage

### DIFF
--- a/utils/params_parser.go
+++ b/utils/params_parser.go
@@ -6,19 +6,29 @@ import (
 	"net/http"
 )
 
-// Helper function to check if all parameters were set by the client. It errors
-// if one of more params are empty.
-func ParseParametersURL(r *http.Request, params ...string) (map[string]string, error) {
+// Helper function to check if required parameters were set by the client, and
+// it will error if either the parameter is defined none or more than once.
+//
+// Note that error implements Unwrap() if it's not nill, meaning you can get
+// all errors that ocurred inside the function and send back to the client.
+func ParseParametersURL(r *http.Request, required ...string) (map[string]string, error) {
 	parsed := make(map[string]string)
-	errs := make([]error, 0, len(params))
+	errs := make([]error, 0, len(required))
 
-	for i := range params {
-		value := r.URL.Query().Get(params[i])
-		if value == "" {
-			errs = append(errs, fmt.Errorf("parameter `%s` is empty", params[i]))
+	for k, v := range r.URL.Query() {
+		if len(v) > 1 {
+			errs = append(errs, fmt.Errorf("`%s` was defined more than once", k))
 		}
 
-		parsed[params[i]] = value
+		if v[0] != "" {
+			parsed[k] = v[0]
+		}
+	}
+
+	for i := range required {
+		if _, ok := parsed[required[i]]; !ok {
+			errs = append(errs, fmt.Errorf("`%s` not set", required[i]))
+		}
 	}
 
 	return parsed, errors.Join(errs...)

--- a/utils/params_parser_test.go
+++ b/utils/params_parser_test.go
@@ -28,15 +28,42 @@ func TestParseParametersSuccess(t *testing.T) {
 }
 
 func TestParseParametersFail(t *testing.T) {
-	r := &http.Request{
-		URL: &url.URL{
-			RawQuery: "user_id=10&guild_id=",
+	r := []http.Request{
+		{
+			URL: &url.URL{
+				RawQuery: "user_id=10&guild_id=",
+			},
+		},
+		{
+			URL: &url.URL{
+				RawQuery: "user_id=10&guild_id=9&guild_id=12",
+			},
 		},
 	}
 
-	_, err := ParseParametersURL(r, "user_id", "guild_id")
-	if err == nil {
+	for i := range r {
+		_, err := ParseParametersURL(&r[i], "user_id", "guild_id")
+		if err == nil {
+			t.Fail()
+		}
+	}
+}
+
+func TestParseParametersOptional(t *testing.T) {
+	r := &http.Request{
+		URL: &url.URL{
+			RawQuery: "user_id=10&guild_id=9&meaning_of_life=42",
+		},
+	}
+
+	vals, err := ParseParametersURL(r, "user_id", "guild_id")
+	if err != nil {
 		t.Fail()
 		t.Log(err.Error())
+	}
+
+	if val, ok := vals["meaning_of_life"]; !ok || val != "42" {
+		t.Fail()
+		t.Logf("meaning_of_life = %s; want 42", val)
 	}
 }


### PR DESCRIPTION
It will now error if the query key is defined more than once.

Closes #7 